### PR TITLE
added dummy data for the frontend via docker

### DIFF
--- a/front-end/dummyDocker/Dockerfile
+++ b/front-end/dummyDocker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:latest
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+COPY . .
+
+ENV PORT=8000
+EXPOSE $PORT
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8510", "--reload"]

--- a/front-end/dummyDocker/main.py
+++ b/front-end/dummyDocker/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+import os
+
+app = FastAPI()
+
+@app.get("/getDummy")
+def getDummy():
+    return {"totalEnergy": 3000,
+            "energyFromGrid":1500,
+            "pvProduction": 1000,
+            "solarPanels":[
+                  {"azimuth":5,
+                   "slope":5},
+                  {"azimuth":10,
+                   "slope":10},
+                   {"azimuth":15,
+                   "slope":15},
+                   {"azimuth":20,
+                   "slope":20},
+                  ]}
+
+if __name__ == "__main__":
+	import uvicorn
+	uvicorn.run(app, host="127.0.0.1", port=8510)

--- a/front-end/dummyDocker/requirements.txt
+++ b/front-end/dummyDocker/requirements.txt
@@ -1,0 +1,2 @@
+fastapi[standard]
+uvicorn

--- a/front-end/dummyDocker/usage.txt
+++ b/front-end/dummyDocker/usage.txt
@@ -1,0 +1,2 @@
+docker build -t dummy-docker .
+docker run -p 8510:8510 dummy-docker


### PR DESCRIPTION
Created a docker container that when the `http://localhost8510/getDummy` is called it will return the following:
```
{"totalEnergy": 3000,
"energyFromGrid":1500,
"pvProduction": 1000,
"solarPanels":[
{"azimuth":5,
"slope":5},
{"azimuth":10,
"slope":10},
{"azimuth":15,
"slope":15},
{"azimuth":20,
"slope":20},
]}
```